### PR TITLE
Add send_as_integration field to threads and comments

### DIFF
--- a/source/includes/_comments.md
+++ b/source/includes/_comments.md
@@ -131,6 +131,7 @@ Adds a new comment to a thread.
 | groups | Array of Numbers | No | The groups that will be notified |
 | temp_id | Number | No | The temporary id of the comment |
 | mark_thread_position | Boolean | No | By default, the position of the thread is marked |
+| send_as_integration | Boolean | No | Displays the integration as the comment creator |
 
 ### Return value
 

--- a/source/includes/_threads.md
+++ b/source/includes/_threads.md
@@ -142,6 +142,7 @@ Adds a new thread to a channel.
 | recipients | Array of Numbers or String | No | The users that will be attached to the thread, or `EVERYONE` |
 | groups | Array of Numbers | No | The groups that will be notified |
 | temp_id | Number | No | The temporary id of the thread |
+| send_as_integration | Boolean | No | Displays the integration as the thread creator |
 
 ### Return value
 


### PR DESCRIPTION
This new parameter makes the object to show as if it was created by
the integration instead of the integration creator.