### PR TITLE
Missed backtick in "Update thread"

### DIFF
--- a/source/includes/_threads.md
+++ b/source/includes/_threads.md
@@ -158,7 +158,7 @@ curl -X POST https://api.twistapp.com/api/v2/threads/update \
   -H "Authorization: Bearer 9b1bf97783c1ad5593dee12f3019079dbd3042cf" \
   -d id=32038 \
   -d title=Thread1
-``
+```
 
 `POST /api/v2/threads/update`
 


### PR DESCRIPTION
Causes formatting error - the Update Thread documentation appears in the codebar, while the Remove Thread documentation appears under the Update Thread heading.

https://api.twistapp.com/#update-thread