### PR TITLE
Fix formatting for thread.recipients field type

### DIFF
--- a/source/includes/v2/_threads.md
+++ b/source/includes/v2/_threads.md
@@ -49,7 +49,7 @@ A thread is a discussion.
 | workspace_id *Integer* | The id of the workspace |
 | attachments *List of [Attachments](#attachments)* | Files attached to the comment |
 | actions *List of [Action buttons](#action-buttons)* | Action buttons attached to the comment |
-| recipients *List of Integers or String | The users that were initially attached to the the thread, or `EVERYONE` |
+| recipients *List of Integers or String* | The users that were initially attached to the the thread, or `EVERYONE` |
 | participants *List of Integers* | The users that were at some point attached to the thread or one of its comments |
 | groups *List of Integers* | The groups that will be notified |
 | reactions *Object* | Reactions to the thread, where keys are the reactions and values the users that had that reaction |


### PR DESCRIPTION
**Before**

![screen shot 2018-02-21 at 11 14 06 am](https://user-images.githubusercontent.com/3893573/36477367-c4f114aa-16f8-11e8-9ecd-7d7d553b1302.png)

**After**

![screen shot 2018-02-21 at 11 15 09 am](https://user-images.githubusercontent.com/3893573/36477366-c4d1d7de-16f8-11e8-81e8-a18b330dc1b5.png)