### PR TITLE
Pointed OAuth URLs to the correct part of the documentation.

### DIFF
--- a/source/includes/v2/_integration_oauth.md
+++ b/source/includes/v2/_integration_oauth.md
@@ -2,7 +2,7 @@
 
 The OAuth integration is the most powerful way to use the Twist API
 but it's also the one that needs more work for a full setup. The
-steps needed to setup are described in our [OAuth2](#oauth2) section.
+steps needed to setup are described in our [OAuth2](#oauth) section.
 
 **Example usage**: Integrate an application with Twist, creating new
 workspaces, channels, threads, and/or messages.
@@ -14,7 +14,7 @@ endpoints of the API for personal purposes or create a proof of
 concept. For these cases, when the OAuth integration is created we
 provide a **test token**.
 
-The test token is a result of the [OAuth2](#oauth2) process for the
+The test token is a result of the [OAuth2](#oauth) process for the
 current logged user and will have the full scope access. 
 
 ```shell

--- a/source/includes/v2/_integration_types.md
+++ b/source/includes/v2/_integration_types.md
@@ -5,7 +5,7 @@ your type based on how your integration will be used. Here are links
 with the full explanation of each one with a small summary of what they
 can do:
 
-* [oAuth 2 applications](#oauth) - Requires more setup but is more powerful.
+* [OAuth 2 applications](#oauth) - Requires more setup but is more powerful.
 * [Channel integration](#channel) - Has access to one channel only, has schedule powers.
 * [Thread integration](#thread) - Has access to one thread or create new threads.
 * [Slash command integration](#slash-command) - Receives a request when called via slash command.

--- a/source/includes/v2/_overview.md
+++ b/source/includes/v2/_overview.md
@@ -9,11 +9,11 @@ parameters, and examples.
 
 Login and signup are done via [/api/v2/users/login](#login)
 and [/api/v2/users/register](#register). For public integration, you must
-use our [oAuth 2 authentication](#oauth-2).
+use our [OAuth 2 authentication](#oauth).
 
 If you just want a token to try the API, we provide a test token when you create
 an application following what we describe in
-the [oAuth 2 authentication](#oauth-2) guide.
+the [OAuth 2 authentication](#oauth) guide.
 
 
 ## Temporary ids


### PR DESCRIPTION
There was some parts of our documentation that were not pointing at the correct URL for OAuth applications.